### PR TITLE
Added scala-jsonapi to "Libraries: Scala"

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 **Scala**
 * [spray-json](https://github.com/spray/spray-json) - A lightweight, clean and simple implementation in Scala.
 * [circle](http://circe.io) - Yet another JSON library for Scala.
+* [scala-jsonapi](https://github.com/zalando/scala-jsonapi) - Support library for integrating the JSON:API spec with Play, Spray and/or Circe backends.
 
 **Swift**
 * [SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON) - The better way to deal with data in Swift.


### PR DESCRIPTION
Hi--scala-jsonapi (https://github.com/zalando/scala-jsonapi) is an open-source Scala support library for integrating the JSON API spec with Spray, Play! or Circe. LMK if you have any questions!