### PR TITLE
Add aptos to JSON Schema Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [DLL.js](https://github.com/moll/js-ddl) - Gets you a JSON Schema from PostgreSQL or SQLite3.
 * [JSONSchema.net](https://jsonschema.net//) - JSON Schema generator from JSON object.
 * [js-schema](https://github.com/molnarg/js-schema) - A new way of describing object schemas in JavaScript. It has a clean and simple syntax, and it is capable of serializing to/from the popular JSON Schema format.
+* [aptos](https://github.com/pennsignals/aptos) - A tool for validating data using JSON Schema and converting JSON Schema documents into different data-interchange formats.
 
 ## JSON Schema Resources
 * [Understanding JSON Schema](https://spacetelescope.github.io/understanding-json-schema/) - A website aiming to provide more accessible documentation for JSON schema.


### PR DESCRIPTION
Add a new link to the `JSON Schema Tools` section with a hyperlink to the [`aptos`](https://github.com/pennsignals/aptos) project.