### PR TITLE
Added ipinfo.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [Rx](http://rx.codesimply.com/) - Simple, Extensible Schemata.
 
 ## Services
+* [ipinfo.io](https://ipinfo.io) - JSON IP and GeoIP REST API.
 * [JSONProxy](https://github.com/afeld/jsonp) - Simple HTTP proxy that enables cross-domain requests to any JSON API.
 * [Myjson](http://myjson.com/) - A simple store for your web or mobile app.
 * [Telize](http://www.telize.com/) - JSON IP and GeoIP REST API.


### PR DESCRIPTION
Added link to https://ipinfo.io free IP geolocation REST API which returns JSON info, eg:

```
$ curl ipinfo.io
{
  "ip": "73.222.35.118",
  "hostname": "c-73-222-35-118.hsd1.ca.comcast.net",
  "city": "Mountain View",
  "region": "California",
  "country": "US",
  "loc": "37.3845,-122.0881",
  "org": "AS7922 Comcast Cable Communications, LLC",
  "postal": "94040"
}
```