### PR TITLE
Add JSON 1.1 / JSONX to format extension section

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [JsonML](http://www.jsonml.org/) - A compact format for transporting XML-based markup as JSON which allows it to be losslessly converted back to its original form.
 * [JSON5](https://json5.org/) - a extension that aims to make it easier for humans to write and maintain by hand.
 * [JSON6](https://github.com/d3x0r/json6) - JSON for Humans (ES6).
+* [JSON 1.1/JSONX](https://json-next.github.io/) - An evolved version 1.1 with format extension for humans incl. comments, unquoted and multi-line strings, optional and trailing commas and more. 
 * [JSON Resume](https://jsonresume.org/) - The open source initiative to create standard for resumes.
 * [JSON Web Tokens](https://jwt.io/) - A compact URL-safe means of representing claims to be transferred between two parties.
 * [JSON API](https://jsonapi.org/) - A standard for building APIs.


### PR DESCRIPTION
Hello, thanks for the awesome JSON page / list. It would be great to see JSON v1.1 also known as JSON with eXtension (JSONX) added to the format extension section. See <https://json-next.github.io/> for more about the JSON11 / JSON v1.1 / JSONX format extension. Greetings from Vienna. Cheers. Prost.