### PR TITLE
jshn a parser for shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [scala-jsonapi](https://github.com/scala-jsonapi/scala-jsonapi) - Support library for integrating the JSON:API spec with Play, Spray and/or Circe backends.
 * [jsoniter-scala](https://github.com/plokhotnyuk/jsoniter-scala) - Scala macros for compile-time generation of ultra-fast JSON codecs.
 
+**Shell**
+* [jshn](https://openwrt.org/docs/guide-developer/jshn) - JSON parsing and generation library in for shell scripts (Ash/Bash)
+
 **Swift**
 * [SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON) - The better way to deal with data in Swift.
 


### PR DESCRIPTION
The library/tool is actively used in OpenWRT but it can be compiled and used on any other Linux distro.
For example I created a PPA for Ubuntu https://github.com/stokito/jshn-jsonc and going to maintain a it for other distros.
Anyway it interesting even just as a technology 