### PR TITLE
Add json-build, a zero-allocation minimalistic JSON serializer in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 **C**
 * [Jansson](https://digip.org/jansson/) - A C library for encoding, decoding and manipulating data.
 * [jsmn](https://zserge.com/jsmn.html) - A minimalistic parser in C. It can be easily integrated into the resource-limited projects or embedded systems.
+* [json-build](https://github.com/lcsmuller/json-build) - A minimalistic serializer in C. It can be easily integrated into the resource-limited projects or embedded systems.
 * [ojc](https://github.com/ohler55/ojc) - A fast JSON parser.
 
 **C++**


### PR DESCRIPTION
This library was created to accommodate the lack of JSON serializing in jsmn, under similar principles and philosophy.