### PR TITLE
Updates to JSON Schema Validators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [jjv](https://github.com/acornejo/jjv) - Javascript Library for Schema Validation.
 * [request-validator](https://github.com/bugventure/request-validator) - Flexible request validator middleware for express and connect.
 * [tv4](https://github.com/geraintluff/tv4) - Tiny Validator.
-* [ajv](https://github.com/ajv-validator/ajv) - The fastest validator. Supports v5/6 proposals.
+* [ajv](https://github.com/ajv-validator/ajv) - The fastest validator. Supports JSON Schema draft-04/06/07/2019-09/2020-12.
 * [v8r](https://github.com/chris48s/v8r) - Smart validator that uses [Schema Store](https://www.schemastore.org) to detect a suitable schema for your input files based on the filename.
 
 **Java and Kotlin**

--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [request-validator](https://github.com/bugventure/request-validator) - Flexible request validator middleware for express and connect.
 * [tv4](https://github.com/geraintluff/tv4) - Tiny Validator.
 * [ajv](https://github.com/ajv-validator/ajv) - The fastest validator. Supports v5/6 proposals.
+* [v8r](https://github.com/chris48s/v8r) - Smart validator that uses [Schema Store](https://www.schemastore.org) to detect a suitable schema for your input files based on the filename.
 
 **Java and Kotlin**
 * [Medeia Validator](https://github.com/worldturner/medeia-validator) - Compliant (draft-04/06/07) and fast streaming validator written in Kotlin

--- a/README.md
+++ b/README.md
@@ -423,7 +423,6 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [jsck](https://github.com/pandastrike/jsck) - JSON Schema Compiled checK.
 * [z-schema](https://github.com/zaggino/z-schema) - validator written in JavaScript for NodeJS and Browsers.
 * [jjv](https://github.com/acornejo/jjv) - Javascript Library for Schema Validation.
-* [request-validator](https://github.com/bugventure/request-validator) - Flexible request validator middleware for express and connect.
 * [tv4](https://github.com/geraintluff/tv4) - Tiny Validator.
 * [ajv](https://github.com/ajv-validator/ajv) - The fastest validator. Supports JSON Schema draft-04/06/07/2019-09/2020-12.
 * [v8r](https://github.com/chris48s/v8r) - Smart validator that uses [Schema Store](https://www.schemastore.org) to detect a suitable schema for your input files based on the filename.


### PR DESCRIPTION
I came here to add [v8r](https://github.com/chris48s/v8r) to this section, but while I was here I noticed a couple of other things.

1. AJV's description was quite out of date with reference to the specification versions it has compatibility with
2. [request-validator](https://github.com/bugventure/request-validator) is deprecated (see the README). I'd suggest this make it not-awesome. The author now points users towards https://github.com/bugventure/jsen which is already listed elsewhere in this section. I suggest removing this