### PR TITLE
Add qjson to C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [JSON++](https://github.com/tunnuz/json) - A self contained Flex/Bison parser for C++11.
 * [json11](https://github.com/dropbox/json11) - A tiny library for C++11.
 * [Nlohmann JSON](https://github.com/nlohmann/json) - A C++11 header-only class.
+* [qjson](https://github.com/qinyonghang/json) - A fast JSON library for C++17 that is header-only.
 * [RapidJSON](https://github.com/Tencent/rapidjson) - A fast JSON parser/generator for C++ with both SAX/DOM style API
 * [simdjson](https://github.com/simdjson/simdjson) - Parsing gigabytes of JSON per second.
 


### PR DESCRIPTION
recommended reasons:
1. High Performance: 6x faster parsing than nlohmann/json, Nearly 3x faster serialization than nlohmann/json
2. Zero-copy: Zero-copy view mode provides additional 2x performance boost
3. header-only
4. C++17