### PR TITLE
Add TOON PHP Lite to the JSON libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 
 **PHP**
 * [Webmozart JSON](https://github.com/webmozart/json) - A robust decoder/encoder with support for schema validation.
+- [TOON PHP Lite](https://github.com/manojrammurthy/toon-php-lite) – Lightweight TOON encoder/decoder for human-readable, LLM-friendly structured data.
 
 **Python**
 * [simplejson](https://github.com/simplejson/simplejson) - A simple, fast, extensible encoder/decoder


### PR DESCRIPTION
This PR adds **TOON PHP Lite** — a lightweight PHP encoder/decoder for
TOON (Token-Oriented Object Notation), a human-readable and LLM-friendly
structured data format.

GitHub: https://github.com/manojrammurthy/toon-php-lite
Packagist: https://packagist.org/packages/manoj/toon-php-lite
