### PR TITLE
Add Toolshref to Transformations Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [Sawmill](https://github.com/logzio/sawmill) - JSON transformation library (Java)
 * [nimnjs](https://github.com/NaturalIntelligence/nimnjs) - JSON to nimn bidirectional converter.
 * [stylops](https://github.com/cruel-intentions/stylops) - CSS subset to JSON conversion. (node.js)
+* [Toolshref](https://toolshref.com) - Online JSON to Java POJO converter and JSON-to-Mermaid visualizer.
 
 ## Queries
 * [dasel](https://github.com/tomwright/dasel) - Query and update data structures using selectors from the command line. Comparable to [jq](https://github.com/jqlang/jq) / [yq](https://github.com/kislyuk/yq) but supports JSON, YAML, TOML and XML with zero runtime dependencies.


### PR DESCRIPTION
Added Toolshref to the list of Transformations.

* **Tool:** Toolshref (https://toolshref.com)
* **Relevance:** It provides a client-side JSON to Java POJO converter and a JSON-to-Mermaid diagram visualizer.
* **Category:** Converters / Visualizers
* **Cost:** Free, no login required.

I have placed the item in alphabetical order as per the guidelines.