### PR TITLE
Add Dadroit V Web to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [JSON Schema Validate API](https://assertible.com/json-schema-validation) - A simple and free JSON Schema Validation API.
 * [JSONPerf](https://jsonperf.com) - A Visual, Unbiased and Up-to-Date JSON Performance Benchmark.
 * [FracturedJson](https://j-brooke.github.io/FracturedJson/) - Formatter that produces human-readable but fairly compact output.
-
+* [Dadroit V Web](https://dadroit.com/vweb/) - In-browser JSON viewer for large files with tree view, RegEx search, and URL loading with auth. Fully client-side.
+  
 ## Schema Specifications
 * [JSON Schema](https://json-schema.org/) - a JSON based format for defining the structure of JSON data.
 * [Itemscript](https://code.google.com/archive/p/itemscript/) - Language for validating and specifying values.


### PR DESCRIPTION
Adding Dadroit V Web to the Online tools section.
V Web is a client-side JSON viewer that handles large files in the browser. It supports tree view navigation, text and RegEx search, export (minified or formatted), and loading JSON from authenticated URLs (Bearer/Basic). No data is uploaded — everything runs locally.

Note: Dadroit JSON Viewer (the desktop app) is already listed under Applications.