### PR TITLE
Add Forge API suite to Transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,9 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [Sawmill](https://github.com/logzio/sawmill) - JSON transformation library (Java)
 * [nimnjs](https://github.com/NaturalIntelligence/nimnjs) - JSON to nimn bidirectional converter.
 * [stylops](https://github.com/cruel-intentions/stylops) - CSS subset to JSON conversion. (node.js)
+* [DocForge API](https://docforge-api.vercel.app/) - REST API for converting between CSV, YAML, and structured data formats.
+* [FormForge API](https://formforge-api.vercel.app/) - REST API for generating themed HTML forms from schema definitions.
+* [ReportForge API](https://reportforge-api.vercel.app/) - REST API for generating PDF reports and charts from structured data.
 
 ## Queries
 * [dasel](https://github.com/tomwright/dasel) - Query and update data structures using selectors from the command line. Comparable to [jq](https://github.com/jqlang/jq) / [yq](https://github.com/kislyuk/yq) but supports JSON, YAML, TOML and XML with zero runtime dependencies.


### PR DESCRIPTION
Adds three REST APIs to the **Transformations** section:

* **DocForge API** — converts between CSV, YAML, and structured data formats.
* * **FormForge API** — generates themed HTML forms from schema definitions.
* * **ReportForge API** — generates PDF reports and charts from structured data.
All three are live, free-tier-available transformation APIs. Descriptions follow the repo format and do not mention JSON (as per contributing guidelines).