### PR TITLE
Add DocForge to Online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [FakeJSON](https://fakejson.com/) - Web API to quickly generate fake data for your application.
 * [JSON to CSV](https://konklone.io/json/) - A free, in-browser JSON to CSV converter.
 * [CSV to JSON](https://alef.website/tools/csv-to-json) - Easy, privacy-friendly and offline-first online csv to json converter
+* [DocForge](https://docforge-api.vercel.app) - Free REST API for converting between CSV/JSON, Markdown/HTML, and YAML/JSON. No signup required.
 * [json2csharp](https://json2csharp.com/) - Generate c# classes from a json string or url.
 * [JSON Utils](http://jsonutils.com/) - Site for generating C#, VB.Net, and Javascript classes from JSON.
 * [geojson.io](https://geojson.io/) - Simply edit GeoJSON map data.


### PR DESCRIPTION
Adding [DocForge](https://docforge-api.vercel.app) to the Online tools section.

DocForge is a free REST API for converting between common data formats:
- CSV to JSON / JSON to CSV
- Markdown to HTML
- YAML to JSON / JSON to YAML

Free tier with 500 requests/day, no signup or API key required.

**Docs:** https://docforge-api.vercel.app/docs