### PR TITLE
Add webtoolz Mock API Builder to Online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [JSONPerf](https://jsonperf.com) - A Visual, Unbiased and Up-to-Date JSON Performance Benchmark.
 * [FracturedJson](https://j-brooke.github.io/FracturedJson/) - Formatter that produces human-readable but fairly compact output.
 
+* [webtoolz Mock API Builder](https://webtoolz.dev/json/mock-api) - Build mock REST APIs in the browser with faker data, conditional responses, and shareable URLs. No signup needed.
 ## Schema Specifications
 * [JSON Schema](https://json-schema.org/) - a JSON based format for defining the structure of JSON data.
 * [Itemscript](https://code.google.com/archive/p/itemscript/) - Language for validating and specifying values.


### PR DESCRIPTION
Hey! Adding a free browser-based mock API builder to the Online tools section.

It lets you define REST endpoints with faker-powered JSON responses, conditional routing, and sequence mode — all in the browser. The config is encoded in the URL (no backend, no accounts).

https://webtoolz.dev/json/mock-api