### PR TITLE
Add LazyFish JSON Schema Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [js-schema](https://github.com/molnarg/js-schema) - A new way of describing object schemas in JavaScript. It has a clean and simple syntax, and it is capable of serializing to/from the popular JSON Schema format.
 * [aptos](https://github.com/pennsignals/aptos) - A tool for validating data using JSON Schema and converting JSON Schema documents into different data-interchange formats.
 * [JSON Schema $Ref Parser](https://github.com/APIDevTools/json-schema-ref-parser) - Parse, resolve, and dereference JSON Schema $ref pointers
+* [LazyFish JSON Schema Builder](https://lazyfish.app/json-schema-builder) - A visual, client-side schema builder that runs entirely in the browser with no data uploads.
 
 ## JSON Schema Resources
 * [Understanding JSON Schema](https://spacetelescope.github.io/understanding-json-schema/) - A website aiming to provide more accessible documentation for JSON schema.


### PR DESCRIPTION
Adds [LazyFish JSON Schema Builder](https://lazyfish.app/json-schema-builder) to the JSON Schema Tools section.

LazyFish JSON Schema Builder is a visual, client-side tool for building JSON schemas. It runs entirely in the browser — no data leaves the user's device.