### PR TITLE
Add jsonutils.org to Online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [CSV to JSON](https://alef.website/tools/csv-to-json) - Easy, privacy-friendly and offline-first online csv to json converter
 * [json2csharp](https://json2csharp.com/) - Generate c# classes from a json string or url.
 * [JSON Utils](http://jsonutils.com/) - Site for generating C#, VB.Net, and Javascript classes from JSON.
+* [JSON Utils](https://jsonutils.org/) - 50+ free, privacy-first online JSON tools including formatter, validator, converters, schema tools, and a jq playground.
 * [geojson.io](https://geojson.io/) - Simply edit GeoJSON map data.
 * [jq play](https://jqplay.org/) - A playground for jq.
 * [json2yaml](https://www.json2yaml.com/) - Convert JSON to YAML online.


### PR DESCRIPTION
Adds JSON Utils (jsonutils.org) to the Online tools section — a free, privacy-first collection of 50+ browser-based JSON tools. All processing is client-side with no registration required.

Note: distinct from the existing jsonutils.com entry (C#/VB.Net class generator).

Closes [#161](https://github.com/burningtree/awesome-json/issues/161)

