### PR TITLE
Add DevTools JSON Formatter to Online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [JSON Selector Generator](http://jsonselector.com/) - A simple GUI for generating the selectors to access.
 * [JSON.fr](https://www.json.fr/) - Fully client-side validator and formatter.
 * [ObjGen](https://www.objgen.com/json) - Online live JSON generator.
+* [DevTools JSON Formatter](https://devtools.davrapps.dev/en/json-formatter) - Free browser-based JSON formatter, validator, and beautifier with tree view. No data sent to servers.
 * [JSONPlaceholder](https://jsonplaceholder.typicode.com/) - Fake Online REST API for Testing and Prototyping.
 * [Extends Class](https://extendsclass.com/json-diff.html) - Diff tool to compare two files.
 * [JSON Schema Validate API](https://assertible.com/json-schema-validation) - A simple and free JSON Schema Validation API.


### PR DESCRIPTION
Hi! Adding [DevTools JSON Formatter](https://devtools.davrapps.dev/en/json-formatter) to the Online tools section.

**What it does:**
- Format, validate, and beautify JSON with syntax highlighting
- Tree view for exploring nested structures
- 100% client-side — no data sent to servers
- Free, no account required

It fits nicely alongside the existing JSON formatters and validators in this list. Thanks for maintaining this awesome resource! 🙏