### PR TITLE
Add DevTools JSON Formatter to Online Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [JSON Schema Validate API](https://assertible.com/json-schema-validation) - A simple and free JSON Schema Validation API.
 * [JSONPerf](https://jsonperf.com) - A Visual, Unbiased and Up-to-Date JSON Performance Benchmark.
 * [FracturedJson](https://j-brooke.github.io/FracturedJson/) - Formatter that produces human-readable but fairly compact output.
+* [DevTools JSON Formatter](https://devtools.davrapps.dev/en/json-formatter) - Format, validate, minify JSON with syntax highlighting. Also includes JSON→TypeScript and JSON↔YAML converters. 100% client-side.
 
 ## Schema Specifications
 * [JSON Schema](https://json-schema.org/) - a JSON based format for defining the structure of JSON data.


### PR DESCRIPTION
Added [DevTools JSON Formatter](https://devtools.davrapps.dev/en/json-formatter) to the Online Tools section.

**What it does:** Format, validate, and minify JSON with syntax highlighting and error detection. The suite also includes JSON→TypeScript converter and JSON↔YAML converter — all running 100% client-side with no data sent to servers.

**Why it fits:** It's a free, privacy-first online JSON tool — similar to the existing entries like JSONLint, JSON Formatter and Validator, and JSON.fr.