### PR TITLE
Add JSON Linter to Online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [json2yaml](https://www.json2yaml.com/) - Convert JSON to YAML online.
 * [JSON Selector Generator](http://jsonselector.com/) - A simple GUI for generating the selectors to access.
 * [JSON.fr](https://www.json.fr/) - Fully client-side validator and formatter.
+* [JSON Linter](https://jsonlinter.dev/) - Single-page validator and formatter with line:column error reporting; runs entirely in the browser.
 * [ObjGen](https://www.objgen.com/json) - Online live JSON generator.
 * [JSONPlaceholder](https://jsonplaceholder.typicode.com/) - Fake Online REST API for Testing and Prototyping.
 * [Extends Class](https://extendsclass.com/json-diff.html) - Diff tool to compare two files.


### PR DESCRIPTION
Adds [jsonlinter.dev](https://jsonlinter.dev/) to the **Online tools** section.

## What it is

A single-page JSON validator and formatter that runs entirely in the
browser. The whole site is a ~9KB HTML file — no framework runtime,
no analytics, no tracking.

Distinguishing features vs. tools already on the list:

- **Line and column error positions** — V8/Safari report errors as a
  character offset; the linter walks the input to translate to
  `line:column` so the error is easy to find.
- **Format / minify with configurable indent** (2, 4, or tab).
- **Works offline** once loaded.
- **No ads or signup walls.**

Placed next to [JSON.fr](https://www.json.fr/) since the pitch is similar
(client-side validator/formatter); happy to move if a different spot
fits better.

## Contributing-guide compliance

- [x] Single line addition, alphabetic-ish placement near similar tools
- [x] Format: `* [Name](url) - description ending with a dot.`
- [x] No mention of "JSON" in the description (implied)
- [x] No trailing whitespace
- [x] Link works (HTTP 200, valid TLS)

## Live link

https://jsonlinter.dev/