### PR TITLE
Add Acento JSON Formatter under Online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [JSON Schema Validate API](https://assertible.com/json-schema-validation) - A simple and free JSON Schema Validation API.
 * [JSONPerf](https://jsonperf.com) - A Visual, Unbiased and Up-to-Date JSON Performance Benchmark.
 * [FracturedJson](https://j-brooke.github.io/FracturedJson/) - Formatter that produces human-readable but fairly compact output.
+* [Acento JSON Formatter](https://www.acento.io/en/json-formatter/) - Format, validate, and minify JSON. 100% client-side, no upload.
 
 ## Schema Specifications
 * [JSON Schema](https://json-schema.org/) - a JSON based format for defining the structure of JSON data.


### PR DESCRIPTION
Adds Acento JSON Formatter under Online tools — formats, validates,
and minifies JSON entirely in the browser. JSON input never leaves
the page (no server upload, unlike some of the existing entries).

Appended at the bottom of the Online tools section.
