### PR TITLE
Add jsontosdk to Online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [CSV to JSON](https://alef.website/tools/csv-to-json) - Easy, privacy-friendly and offline-first online csv to json converter
 * [json2csharp](https://json2csharp.com/) - Generate c# classes from a json string or url.
 * [JSON Utils](http://jsonutils.com/) - Site for generating C#, VB.Net, and Javascript classes from JSON.
+* [jsontosdk](https://jsontosdk.vercel.app) - Paste a JSON sample, get typed TypeScript interfaces + a Zod schema with LLM-named types. No signup.
 * [geojson.io](https://geojson.io/) - Simply edit GeoJSON map data.
 * [jq play](https://jqplay.org/) - A playground for jq.
 * [json2yaml](https://www.json2yaml.com/) - Convert JSON to YAML online.


### PR DESCRIPTION
Adds **jsontosdk** under the `Online tools` section, alongside
`json2csharp` and `JSON Utils` which generate language classes from
JSON for C#/VB.

- Live tool: https://jsontosdk.vercel.app
- What it does: paste a JSON sample → typed TypeScript interfaces +
  a matching Zod schema, in ~5 seconds. Types are LLM-named so
  nested objects get sensible identifiers (e.g. `User` / `Post`)
  instead of generic placeholders.
- No signup, free for payloads ≤ 100 KB, 20 generations / hr / IP.

Same shape as the existing C# / VB / JavaScript class generators in
that section, just for TS + Zod.