### PR TITLE
Add jsonic to Online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [JSON Schema Validate API](https://assertible.com/json-schema-validation) - A simple and free JSON Schema Validation API.
 * [JSONPerf](https://jsonperf.com) - A Visual, Unbiased and Up-to-Date JSON Performance Benchmark.
 * [FracturedJson](https://j-brooke.github.io/FracturedJson/) - Formatter that produces human-readable but fairly compact output.
+* [jsonic](https://jsonic.io) - Format, validate and convert JSON to CSV, YAML and TypeScript in the browser. Client-side, no signup.
 
 ## Schema Specifications
 * [JSON Schema](https://json-schema.org/) - a JSON based format for defining the structure of JSON data.


### PR DESCRIPTION
Adds [jsonic](https://jsonic.io) to the **Online tools** section.

A free, in-browser JSON formatter, validator and converter (JSON to CSV / YAML / TypeScript). Everything runs client-side — no signup, no upload. Fits alongside the existing online formatter/validator entries (JSONLint, JSON Editor online, json2csharp, etc.).