### PR TITLE
Add AI JSONMedic to Online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list.
 * [JSON Lint](https://github.com/Seldaek/jsonlint) - PHP linter. (PHP)
 
 ## Online tools
+* [AI JSONMedic](https://aijsonmedic.com/) - Repairs malformed JSON from LLMs (markdown fences, trailing commas, Python literals, truncation) fully client-side, with format/validate/diff/convert and JSON Schema + TypeScript generation.
 * [Dadroit V Web](https://dadroit.com/vweb/) - In-browser viewer for large files with tree view, RegEx search, and URL loading with auth. Fully client-side.
 * [DataFormatter Pro](https://dataformatterpro.com/) - Browser-based formatter, validator, diff, and converter with a tree view.
 * [JSON Blob](https://jsonblob.com/) - An online tool to view, edit, format, and share data. Also has an API for making requests against stored blobs.


### PR DESCRIPTION
Adds AI JSONMedic (https://aijsonmedic.com) under Online tools.

It's a free, fully client-side tool focused on repairing malformed JSON from LLMs — markdown ```json``` fences, trailing commas, single/smart quotes, Python True/False/None, unclosed brackets from truncated streaming, concatenated/NDJSON — and it reports every change it makes. It also covers format/minify, validate, tree view, diff, convert (CSV/YAML/XML/SQL), JSONPath, JSON Schema + TypeScript generation, and JWT decode. No signup; nothing is uploaded.

Verified live and on-topic for the Online tools section. Thanks for maintaining the list!